### PR TITLE
fix(ui): correct typos in init methods and fix MKUSearchHeaderView ba…

### DIFF
--- a/UtilityiOS/ViewControllers/Mutable/MKUMutableObjectTableViewController.h
+++ b/UtilityiOS/ViewControllers/Mutable/MKUMutableObjectTableViewController.h
@@ -219,7 +219,7 @@ typedef NS_ENUM(NSInteger, MKU_MUTABLE_OBJECT_FIELD_TYPE) {
 @property (nonatomic, assign) MKU_MUTABLE_OBJECT_FIELD_TYPE type;
 
 /** @brief Creates an instance with a single section of the given type. */
-- (instancetype)initWithMKUType:(MKU_MUTABLE_OBJECT_FIELD_TYPE)type;
+- (instancetype)initWithType:(MKU_MUTABLE_OBJECT_FIELD_TYPE)type;
 
 @end
 

--- a/UtilityiOS/ViewControllers/Mutable/MKUMutableObjectTableViewController.m
+++ b/UtilityiOS/ViewControllers/Mutable/MKUMutableObjectTableViewController.m
@@ -1352,7 +1352,7 @@
 
 @implementation MKUMutableObjectTableViewControllerSingle
 
-- (instancetype)initWithMKUType:(MKU_MUTABLE_OBJECT_FIELD_TYPE)type {
+- (instancetype)initWithType:(MKU_MUTABLE_OBJECT_FIELD_TYPE)type {
     if (self = [super init]) {
         self.type = type;
     }

--- a/UtilityiOS/Views/MKUSearchHeaderView.m
+++ b/UtilityiOS/Views/MKUSearchHeaderView.m
@@ -58,7 +58,7 @@
 }
 
 - (void)initBase {
-    self.backgroundColor = [AppTheme searchBarTintColor];
+    self.backgroundColor = [AppTheme searchBarBackgroundColor];
     
     self.searchBar = [[UISearchBar alloc] init];
     self.searchBar.searchBarStyle = UISearchBarStyleMinimal;


### PR DESCRIPTION
…ckground

- Fixed typo in init  method of MKUMutableObjectTableViewControllerSingle which was overriding superclass and preventing MKUType from being set.
- Fixed background view color of MKUSearchHeaderView. 